### PR TITLE
Add Auferet (AI game master) to Gaming

### DIFF
--- a/content/tools/auferet.md
+++ b/content/tools/auferet.md
@@ -1,0 +1,16 @@
+---
+title: 'Auferet'
+name: 'Auferet'
+subtitle: 'AI game master for solo text adventures and tabletop RPGs'
+slug: 'auferet'
+description: 'Auferet is an AI game master for solo text adventures and tabletop-style RPGs. It keeps a long-term memory of your story and lets you upload your own lore documents (retrieval-augmented), so the world stays consistent across long play sessions. It runs as a web app and a published Android app, with a free daily tier.'
+website: 'https://auferet.com'
+logo_url: ''
+category: 'gaming'
+category_name: 'Gaming'
+price: 'Freemium'
+featured: false
+rank: 99
+date: '2026-06-23'
+tags: [gaming, creative, entertainment, games, interactive, storytelling, rpg, npcs, immersive]
+---


### PR DESCRIPTION
Adds **Auferet** to the Gaming category (alongside AI Dungeon) as a new `content/tools/auferet.md`.

Auferet is an AI game master for solo text adventures and tabletop-style RPGs. It keeps a long-term memory of your story and supports uploading your own lore documents (retrieval-augmented), so the world stays consistent across long sessions. It runs as a web app and a published Android app, with a free daily tier. The file follows the existing tool schema.