### PR TITLE
Add tool: GPTGeminiGrok.AI

### DIFF
--- a/content/tools/gptgeminigrok-ai.md
+++ b/content/tools/gptgeminigrok-ai.md
@@ -1,0 +1,13 @@
+---
+title: 'GPTGeminiGrok.AI'
+name: 'GPTGeminiGrok.AI'
+slug: 'gptgeminigrok-ai'
+description: 'Grok-focused AI gateway with GPTPlus, GeminiPro and ClaudeProMax nodes.'
+website: 'https://trygrokai.asia/list/#/home'
+logo_url: ''
+category: 'chatbots'
+category_name: 'Chatbots'
+price: 'Paid'
+featured: false
+date: '2026-07-06'
+---


### PR DESCRIPTION
## Add tool: GPTGeminiGrok.AI

Automatically generated from issue #143 submitted by @xianyu110.

### Tool details
| Field | Value |
|-------|-------|
| Name | GPTGeminiGrok.AI |
| Website | https://trygrokai.asia/list/#/home |
| Category | Chatbots |
| Price | Paid |
| Description | Grok-focused AI gateway with GPTPlus, GeminiPro and ClaudeProMax nodes. |

---
> 🤖 *This PR was created automatically after passing rule-based validation. Please review before merging.*

Closes #143