### PR TITLE
Add Pilot Protocol to AI Agents category

### DIFF
--- a/content/tools/pilot-protocol.md
+++ b/content/tools/pilot-protocol.md
@@ -1,0 +1,15 @@
+---
+title: 'Pilot Protocol'
+name: 'Pilot Protocol'
+subtitle: 'Overlay network giving AI agents a permanent address, encrypted tunnels, and an app store'
+slug: 'pilot-protocol'
+description: 'Pilot Protocol is an open-source overlay network built for AI agents. Every agent gets a permanent virtual address that survives restarts and IP changes, encrypted UDP tunnels (X25519 + AES-GCM) with STUN/hole-punching NAT traversal, and an explicit per-peer trust model where membership and trust are decoupled. It also ships an app store of installable, agent-native capability apps that run locally as typed JSON-in/JSON-out services, discoverable and callable via pilotctl. Written in Go with zero external dependencies, licensed AGPL-3.0.'
+website: 'https://pilotprotocol.network'
+logo_url: ''
+category: 'ai-agents'
+category_name: 'AI Agents'
+price: 'Free'
+featured: false
+date: '2026-07-07'
+tags: [ai-agents, networking, overlay-network, p2p, open-source, devtools, nat-traversal, mcp]
+---


### PR DESCRIPTION
Adds **Pilot Protocol** (https://pilotprotocol.network), an open-source overlay network for AI agents — permanent virtual addressing, encrypted UDP tunnels with NAT traversal, explicit per-peer trust, and an app store of installable agent-native capability apps. Written in Go, zero external dependencies, AGPL-3.0. Fits the AI Agents category alongside other agent infrastructure tools. Follows the front-matter format in CONTRIBUTING.md.