### PR TITLE
Add Hellomatik to Customer Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ Visit **[bestofai.io](https://bestofai.io)** for the full interactive directory 
 - **[Freshdesk](https://freshdesk.com)** — [review](https://bestofai.io/tools/freshdesk/) — AI-driven customer support software with automation ![Freemium](https://img.shields.io/badge/-Freemium-d29922?style=flat-square)
 - **[Intercom](https://intercom.com)** — [review](https://bestofai.io/tools/intercom/) — AI-powered customer messaging and support platform ![Paid](https://img.shields.io/badge/-Paid-8b949e?style=flat-square)
 - **[Zendesk](https://zendesk.com)** — [review](https://bestofai.io/tools/zendesk/) — AI-enhanced customer service and support platform ![Paid](https://img.shields.io/badge/-Paid-8b949e?style=flat-square)
+- **[Hellomatik](https://hellomatik.com)** — AI agent platform that turns company knowledge into agents that answer, sell and book across WhatsApp, email and web ![Paid](https://img.shields.io/badge/-Paid-8b949e?style=flat-square)
 - *[View all 27 Customer Support tools on bestofai.io →](https://bestofai.io/categories/customer-support/)*
 
 ---

--- a/README.md
+++ b/README.md
@@ -357,7 +357,6 @@ Visit **[bestofai.io](https://bestofai.io)** for the full interactive directory 
 - **[Freshdesk](https://freshdesk.com)** — [review](https://bestofai.io/tools/freshdesk/) — AI-driven customer support software with automation ![Freemium](https://img.shields.io/badge/-Freemium-d29922?style=flat-square)
 - **[Intercom](https://intercom.com)** — [review](https://bestofai.io/tools/intercom/) — AI-powered customer messaging and support platform ![Paid](https://img.shields.io/badge/-Paid-8b949e?style=flat-square)
 - **[Zendesk](https://zendesk.com)** — [review](https://bestofai.io/tools/zendesk/) — AI-enhanced customer service and support platform ![Paid](https://img.shields.io/badge/-Paid-8b949e?style=flat-square)
-- **[Hellomatik](https://hellomatik.com)** — AI agent platform that turns company knowledge into agents that answer, sell and book across WhatsApp, email and web ![Paid](https://img.shields.io/badge/-Paid-8b949e?style=flat-square)
 - *[View all 27 Customer Support tools on bestofai.io →](https://bestofai.io/categories/customer-support/)*
 
 ---

--- a/content/tools/hellomatik.md
+++ b/content/tools/hellomatik.md
@@ -1,0 +1,23 @@
+---
+title: 'Hellomatik'
+name: 'Hellomatik'
+subtitle: 'AI agent platform that answers, sells and books across WhatsApp, email, web and phone'
+slug: 'hellomatik'
+description: 'Hellomatik is an AI agent platform that turns a company knowledge base into agents handling customer support, assisted selling and back-office processes across WhatsApp, web chat, email and phone. Agents answer questions 24/7, book and reschedule appointments, generate quotes from price lists and follow up on invoices, connecting to existing systems through integrations such as Shopify, Stripe and Sage without code.'
+website: 'https://hellomatik.com'
+company: 'hellomatik'
+logo_url: ''
+category: 'customer-support'
+category_name: 'Customer Support'
+price: 'Paid'
+featured: false
+rank: 100
+alternatives:
+  - intercom
+  - zendesk
+  - freshdesk
+date: '2026-07-21'
+tags: [customer_support, chatbot, business, whatsapp, voice_ai, ai_agents, automation, booking, scheduling, multichannel]
+---
+
+Hellomatik lets companies build AI agents from their own knowledge that answer, sell and execute across WhatsApp, web chat, email and phone. Common use cases include 24/7 customer support, assisted selling inside a store chat, appointment booking and rescheduling, quote generation from price lists, invoice follow-up and automated management reports. Agents connect to existing systems and integrations (such as Shopify, Stripe and Sage) and can be assembled into workflows without code.


### PR DESCRIPTION
Adds **Hellomatik** to Customer Support. AI agent platform that turns a company's knowledge into agents that answer, sell and book across WhatsApp, email and web — peer to Intercom/Drift already listed. Omitted the /tools/ review link so a maintainer can generate it. Thanks!