### PR TITLE
Add Orkas

### DIFF
--- a/content/tools/orkas.md
+++ b/content/tools/orkas.md
@@ -1,0 +1,13 @@
+---
+title: 'Orkas'
+name: 'Orkas'
+slug: 'orkas'
+description: 'Open-source, local-first desktop AI workforce where a Commander coordinates specialist agents in parallel or sequence through one chat. It supports BYO model keys and keeps conversations, files, agent configurations, and keys on the user''s machine.'
+website: 'https://orkas.ai?source=gh-bestai'
+logo_url: ''
+category: 'ai-agents'
+category_name: 'AI Agents'
+price: 'Free'
+featured: false
+date: '2026-07-22'
+---


### PR DESCRIPTION
## Summary
- add Orkas to the AI Agents category
- link the official website with a distinct source tag and the MIT-licensed repository

## Why it fits
Orkas is an open-source, local-first desktop AI workforce. A Commander coordinates specialist agents in parallel or sequence through one chat, and users bring their own model keys.

## Verification
- Official site: https://orkas.ai?source=gh-bestai
- Source: https://github.com/Orkas-AI/Orkas