### PR TITLE
Add tool: StopwatchPro

### DIFF
--- a/content/tools/stopwatchpro.md
+++ b/content/tools/stopwatchpro.md
@@ -1,0 +1,13 @@
+---
+title: 'StopwatchPro'
+name: 'StopwatchPro'
+slug: 'stopwatchpro'
+description: 'StopwatchPro is a free, browser-based stopwatch and lap timer. There's nothing to download, no account to create, and no fees. Just open the page and start timing — whether you're on a phone, tablet, or desktop computer.'
+website: 'https://stopwatchpro.xyz/index.html'
+logo_url: ''
+category: 'sports-analytics'
+category_name: 'Sports Analytics'
+price: 'Free'
+featured: false
+date: '2026-07-23'
+---


### PR DESCRIPTION
## Add tool: StopwatchPro

Automatically generated from issue #213 submitted by @burrell001-max.

### Tool details
| Field | Value |
|-------|-------|
| Name | StopwatchPro |
| Website | https://stopwatchpro.xyz/index.html |
| Category | Sports Analytics (sports-analytics) |
| Price | Free |
| Description | StopwatchPro is a free, browser-based stopwatch and lap timer. There's nothing to download, no account to create, and no fees. Just open the page and start timing — whether you're on a phone, tablet, or desktop computer. |

---
> 🤖 *This PR was created automatically after passing rule-based validation. Please review before merging.*

Closes #213