### PR TITLE
Add tool: CorpusIQ

### DIFF
--- a/content/tools/corpusiq.md
+++ b/content/tools/corpusiq.md
@@ -1,0 +1,13 @@
+---
+title: 'CorpusIQ'
+name: 'CorpusIQ'
+slug: 'corpusiq'
+description: 'Professionals lose hours searching across dashboards, spreadsheets, emails, and business systems just to answer one question. CorpusIQ connects ChatGPT, Claude, and Perplexity to live company data and returns one cross-source answer with citations.'
+website: 'https://www.corpusiq.io'
+logo_url: ''
+category: 'database-tools'
+category_name: 'Database Tools'
+price: 'Freemium'
+featured: false
+date: '2026-07-24'
+---


### PR DESCRIPTION
## Add tool: CorpusIQ

Automatically generated from issue #219 submitted by @brandonb-sketch.

### Tool details
| Field | Value |
|-------|-------|
| Name | CorpusIQ |
| Website | https://www.corpusiq.io/ |
| Category | Database Tools (database-tools) |
| Price | Freemium |
| Description | Professionals lose hours searching across dashboards, spreadsheets, emails, and business systems just to answer one question. CorpusIQ connects ChatGPT, Claude, and Perplexity to live company data and returns one cross-source answer with citations. |

---
> 🤖 *This PR was created automatically after passing rule-based validation. Please review before merging.*

Closes #219