### PR TITLE
Add Image Describer

### DIFF
--- a/content/tools/image-describer.md
+++ b/content/tools/image-describer.md
@@ -1,0 +1,13 @@
+---
+title: 'Image Describer'
+name: 'Image Describer'
+slug: 'image-describer'
+description: 'Image Describer analyzes uploaded images and generates plain-language descriptions, accessibility-focused alt text, captions, OCR text, and structured prompts. It supports both individual images and batch-oriented content workflows.'
+website: 'https://imagedescriber.dev'
+logo_url: ''
+category: 'accessibility'
+category_name: 'Accessibility'
+price: 'Freemium'
+featured: false
+date: '2026-07-27'
+---


### PR DESCRIPTION
## What changed

- Added a neutral directory entry for Image Describer.
- Used the existing Accessibility category and the canonical product URL.

## Why

Image Describer is not currently present in the directory and its image-description and alt-text workflow fits the existing accessibility category.

## Disclosure

This is a self-submission from the product team.

## Validation

- Confirmed no existing `imagedescriber.dev` entry in the repository.
- Ran `git diff --check`.
- Matched the documented front-matter format and an existing category slug.
