### PR TITLE
Add tool: Statewave.ai

### DIFF
--- a/content/tools/statewave-ai.md
+++ b/content/tools/statewave-ai.md
@@ -1,0 +1,13 @@
+---
+title: 'Statewave.ai'
+name: 'Statewave.ai'
+slug: 'statewave-ai'
+description: 'Statewave is an open-source, self-hosted memory runtime for AI agents. Beyond retrieval, it adds governance - access policies, sensitivity labels, tamper-evident audit receipts - and full source provenance, so every memory traces to where it came from. Apache 2.0.'
+website: 'https://www.statewave.ai'
+logo_url: ''
+category: 'ai-agents'
+category_name: 'Ai Agents'
+price: 'Free'
+featured: false
+date: '2026-07-28'
+---


### PR DESCRIPTION
## Add tool: Statewave.ai

Automatically generated from issue #239 submitted by @kschnier.

### Tool details
| Field | Value |
|-------|-------|
| Name | Statewave.ai |
| Website | https://www.statewave.ai/ |
| Category | AI Agents (ai-agents) |
| Price | Free |
| Description | Statewave is an open-source, self-hosted memory runtime for AI agents. Beyond retrieval, it adds governance - access policies, sensitivity labels, tamper-evident audit receipts - and full source provenance, so every memory traces to where it came from. Apache 2.0. |

---
> 🤖 *This PR was created automatically after passing rule-based validation. Please review before merging.*

Closes #239