### PR TITLE
Add IdeaHunter

### DIFF
--- a/content/tools/ideahunter.md
+++ b/content/tools/ideahunter.md
@@ -1,0 +1,22 @@
+---
+title: 'IdeaHunter'
+name: 'IdeaHunter'
+subtitle: 'Demand-backed startup idea research for solo founders'
+slug: 'ideahunter'
+description: 'IdeaHunter helps solo founders find demand-backed app and micro-SaaS ideas using public signals, buyer pain, market evidence, MVP scope, and monetization paths. Indie hackers, vibe coders, and part-time builders use it to move from generic idea generation toward specific opportunities with source context and a clearer validation path before committing weeks of development time.'
+website: 'https://ideahunter.today'
+logo_url: 'https://ideahunter.today/og-default.png'
+category: 'research-tools'
+category_name: 'Research Tools'
+price: 'Freemium'
+featured: false
+rank: 5
+alternatives:
+  - ideamap-ai
+  - semantic-scholar
+  - perplexity-research
+  - page-pulse
+  - obviously-ai
+date: '2026-08-15'
+tags: [startup_ideas, market_research, validation, founder_tools, research, saas, freemium, product_research]
+---


### PR DESCRIPTION
Adds IdeaHunter as a research tool for founder startup idea validation and demand-backed micro-SaaS research.

Verified live before submission:
- https://ideahunter.today returns HTTP 200
- https://ideahunter.today/og-default.png returns HTTP 200 image/png