### PR TITLE
Add Lunalisa to Image Generation

### DIFF
--- a/content/tools/lunalisa.md
+++ b/content/tools/lunalisa.md
@@ -1,0 +1,15 @@
+---
+title: 'Lunalisa'
+name: 'Lunalisa'
+subtitle: 'AI workspace for product photography and marketing images'
+slug: 'lunalisa'
+description: 'Lunalisa is an AI-powered creative workspace for generating images and videos from text prompts or reference media, spanning 13 image models and 22 video models. It focuses on product photography, marketing posters, and white-background listing images for ecommerce sellers and design teams, producing stills up to 4K across 16 aspect ratios alongside image-to-video and video-to-video generation.'
+website: 'https://luna-lisa.art'
+logo_url: ''
+category: 'image-generation'
+category_name: 'Image Generation'
+price: 'Freemium'
+featured: false
+date: '2026-09-03'
+tags: [image_generation, video_generation, ecommerce, product_photography, creative, text_to_image, image_to_video]
+---


### PR DESCRIPTION
Adds Lunalisa (https://luna-lisa.art) as content/tools/lunalisa.md, category Image Generation, following the front-matter format used by other entries (e.g. nano-banana-pro.md). Lunalisa is an AI creative workspace spanning 13 image and 22 video models, focused on product photography, marketing posters, and white-background listing images for ecommerce sellers, with stills up to 4K across 16 aspect ratios. Freemium pricing with free credits on signup.