### PR TITLE
Add AI Weekly to AI Newsletters

### DIFF
--- a/content/tools/ai-weekly.md
+++ b/content/tools/ai-weekly.md
@@ -1,0 +1,14 @@
+---
+title: 'AI Weekly'
+name: 'AI Weekly'
+subtitle: 'AI news intelligence and expert-reading signals, three times a week'
+slug: 'ai-weekly'
+description: 'AI Weekly tracks what influential AI experts and organizations are reading and sharing, then ranks and explains developments in models, agents, funding, policy, research, companies, and people shaping the field. Its free editions reach more than 53,000 professionals three times a week.'
+website: 'https://aiweekly.co/'
+logo_url: 'https://dxj7eshgz03ln.cloudfront.net/production/publication/logo/1475/8f402391-cd29-43a4-9695-35d930a59660.png'
+category: 'ai-newsletters'
+category_name: 'AI Newsletters'
+price: 'Free'
+featured: false
+date: '2026-09-05'
+---


### PR DESCRIPTION
Adds AI Weekly to the AI Newsletters category using the repository's content-file schema. AI Weekly has operated since 2015 and reaches 53,000+ professionals with free editions three times a week. I’m affiliated with AI Weekly; the description is factual and the entry is not featured.